### PR TITLE
Fixes positioning of child elements with $child->order = 0

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -28,7 +28,7 @@
 				
 				foreach($children as $child){
 					$order = $child->order;
-					if(empty($order)){
+					if($order === NULL){
 						$order = $child->time_created;
 					}
 					


### PR DESCRIPTION
empty($child->order) returns true for 0, so they ordered by time_created instead.

Changing to $child->order === NULL allows 0 to be sorted numerically, and all unordered children to use time_created

The 0 indexes are from pages upgraded from pages_tree
