### PR TITLE
Adds tooltips to page links

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -138,6 +138,7 @@
 					elgg_register_menu_item("pages_nav", array(
 						"name" => "page_" . $child->getGUID(),
 						"text" => $child->title,
+						"title" => $child->title,
 						"href" => $child->getURL(),
 						"rel" => $child->getGUID(),
 						"item_class" => $class,


### PR DESCRIPTION
With infinite depth at a few levels down the page titles exit the view of the screen.  While there is a scroll bar to accommodate the area tooltips may be more useful, and take very little to implement.
